### PR TITLE
Parse description, Update src in <script>, Add nodes to HTML

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,8 +63,8 @@ function transformFile(filePath) {
     });
 
     if (originalScripts.length != transformedScripts.length) {
-      debug.error("originalScripts length", originalScripts.length);
-      debug.error("transformedScripts length", transformedScripts.length);
+      debug.error('originalScripts length', originalScripts.length);
+      debug.error('transformedScripts length', transformedScripts.length);
       throw Error('originalScripts and transformedScripts differ in length');
     }
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+const debug = require('debug')('index');
 const flags = require('flags');
 const fs = require('fs');
 
@@ -36,7 +37,7 @@ async function main() {
 }
 
 function transformFile(filePath) {
-  console.log('Starting transformation on', filePath);
+  debug('Starting transformation on', filePath);
 
   try {
     const transformedScripts = [];
@@ -61,25 +62,28 @@ function transformFile(filePath) {
       }
     });
 
-    if (originalScripts.length != transformedScripts) {
+    if (originalScripts.length != transformedScripts.length) {
+      debug.error("originalScripts length", originalScripts.length);
+      debug.error("transformedScripts length", transformedScripts.length);
       throw Error('originalScripts and transformedScripts differ in length');
     }
 
     // If the title is still undefined after searching scripts for definitions,
     // use the filepath.
     if (title === '') {
+      debug('Title empty after transformation, using', filepath);
       title = filePath;
     }
 
     injectScriptsIntoHTML(filePath, transformedScripts, title, outputPath);
-    console.log('Completed transformation, wrote', outputPath);
+    debug('Completed transformation, wrote', outputPath);
   } catch (err) {
-    console.log('Error while transforming', filePath);
-    console.log(err);
+    debug('Error while transforming', filePath);
+    debug(err);
   }
 }
 
 main().catch((reason) => {
-  console.error(reason);
+  debug.error(reason);
   process.exit(1);
 });

--- a/index.js
+++ b/index.js
@@ -61,11 +61,16 @@ function transformFile(filePath) {
       }
     });
 
+    if (originalScripts.length != transformedScripts) {
+      throw Error('originalScripts and transformedScripts differ in length');
+    }
+
     // If the title is still undefined after searching scripts for definitions,
     // use the filepath.
     if (title === '') {
-      title = 'testing ' + filePath;
+      title = filePath;
     }
+
     injectScriptsIntoHTML(filePath, transformedScripts, title, outputPath);
     console.log('Completed transformation, wrote', outputPath);
   } catch (err) {

--- a/index.js
+++ b/index.js
@@ -40,9 +40,19 @@ function transformFile(filePath) {
 
   try {
     const transformedScripts = [];
+    let addSetup = true;
     const originalScripts = extractScriptsFromHTML(filePath);
     originalScripts.forEach((script) => {
-      const newScript = transformSourceCodeString(script);
+      // Handles the <script src="js-test.js"></script> tags
+      if (script === '') {
+        transformedScripts.push(script);
+        return;
+      }
+      const newScript = transformSourceCodeString(script, addSetup);
+      // Only add setup() once, to the first non-empty script.
+      if (addSetup) {
+        addSetup = false;
+      }
       transformedScripts.push(newScript);
     });
     injectScriptsIntoHTML(filePath, transformedScripts, outputPath);

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ function transformFile(filePath) {
   try {
     const transformedScripts = [];
     let addSetup = true;
+    let title = '';
     const originalScripts = extractScriptsFromHTML(filePath);
     originalScripts.forEach((script) => {
       // Handles the <script src="js-test.js"></script> tags
@@ -48,14 +49,24 @@ function transformFile(filePath) {
         transformedScripts.push(script);
         return;
       }
-      const newScript = transformSourceCodeString(script, addSetup);
+      const transformation = transformSourceCodeString(script, addSetup);
       // Only add setup() once, to the first non-empty script.
       if (addSetup) {
         addSetup = false;
       }
-      transformedScripts.push(newScript);
+      transformedScripts.push(transformation.code);
+      // Use the first title description that appears in the old file.
+      if (title === '') {
+        title = transformation.title;
+      }
     });
-    injectScriptsIntoHTML(filePath, transformedScripts, outputPath);
+
+    // If the title is still undefined after searching scripts for definitions,
+    // use the filepath.
+    if (title === '') {
+      title = 'testing ' + filePath;
+    }
+    injectScriptsIntoHTML(filePath, transformedScripts, title, outputPath);
     console.log('Completed transformation, wrote', outputPath);
   } catch (err) {
     console.log('Error while transforming', filePath);

--- a/package-lock.json
+++ b/package-lock.json
@@ -567,20 +567,10 @@
         "which": "^2.0.1"
       }
     },
-    "d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "requires": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
-    },
     "debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-      "dev": true,
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
         "ms": "^2.1.1"
       }
@@ -651,15 +641,6 @@
         "dom-serializer": "^0.2.1",
         "domelementtype": "^2.0.1",
         "domhandler": "^3.0.0"
-      }
-    },
-    "duration": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/duration/-/duration-0.2.2.tgz",
-      "integrity": "sha512-06kgtea+bGreF5eKYgI/36A6pLXggY7oR4p1pq4SmdFBn1ReOL5D8RhG64VrqfTTKNucqqtBAwEj8aB88mcqrg==",
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.46"
       }
     },
     "emoji-regex": {
@@ -739,35 +720,6 @@
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
-      }
-    },
-    "es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      }
-    },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "requires": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
       }
     },
     "escape-string-regexp": {
@@ -986,30 +938,6 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
-    },
-    "event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      }
-    },
-    "ext": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-      "requires": {
-        "type": "^2.0.0"
-      },
-      "dependencies": {
-        "type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
-        }
-      }
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -1432,19 +1360,6 @@
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
-    "log": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/log/-/log-6.0.0.tgz",
-      "integrity": "sha512-sxChESNYJ/EcQv8C7xpmxhtTOngoXuMEqGDAkhXBEmt3MAzM3SM/TmIBOqnMEVdrOv1+VgZoYbo6U2GemQiU4g==",
-      "requires": {
-        "d": "^1.0.0",
-        "duration": "^0.2.2",
-        "es5-ext": "^0.10.49",
-        "event-emitter": "^0.3.5",
-        "sprintf-kit": "^2.0.0",
-        "type": "^1.0.1"
-      }
-    },
     "log-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
@@ -1508,6 +1423,17 @@
         "yargs": "13.3.2",
         "yargs-parser": "13.1.2",
         "yargs-unparser": "1.6.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
       }
     },
     "ms": {
@@ -1520,11 +1446,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -1855,14 +1776,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "sprintf-kit": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sprintf-kit/-/sprintf-kit-2.0.0.tgz",
-      "integrity": "sha512-/0d2YTn8ZFVpIPAU230S9ZLF8WDkSSRWvh/UOLM7zzvkCchum1TtouRgyV8OfgOaYilSGU4lSSqzwBXJVlAwUw==",
-      "requires": {
-        "es5-ext": "^0.10.46"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -2008,11 +1921,6 @@
       "requires": {
         "is-number": "^7.0.0"
       }
-    },
-    "type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -567,6 +567,15 @@
         "which": "^2.0.1"
       }
     },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
     "debug": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -642,6 +651,15 @@
         "dom-serializer": "^0.2.1",
         "domelementtype": "^2.0.1",
         "domhandler": "^3.0.0"
+      }
+    },
+    "duration": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/duration/-/duration-0.2.2.tgz",
+      "integrity": "sha512-06kgtea+bGreF5eKYgI/36A6pLXggY7oR4p1pq4SmdFBn1ReOL5D8RhG64VrqfTTKNucqqtBAwEj8aB88mcqrg==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.46"
       }
     },
     "emoji-regex": {
@@ -721,6 +739,35 @@
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
       }
     },
     "escape-string-regexp": {
@@ -939,6 +986,30 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "ext": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "requires": {
+        "type": "^2.0.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+        }
+      }
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -1361,6 +1432,19 @@
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
+    "log": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log/-/log-6.0.0.tgz",
+      "integrity": "sha512-sxChESNYJ/EcQv8C7xpmxhtTOngoXuMEqGDAkhXBEmt3MAzM3SM/TmIBOqnMEVdrOv1+VgZoYbo6U2GemQiU4g==",
+      "requires": {
+        "d": "^1.0.0",
+        "duration": "^0.2.2",
+        "es5-ext": "^0.10.49",
+        "event-emitter": "^0.3.5",
+        "sprintf-kit": "^2.0.0",
+        "type": "^1.0.1"
+      }
+    },
     "log-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
@@ -1436,6 +1520,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -1766,6 +1855,14 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "sprintf-kit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sprintf-kit/-/sprintf-kit-2.0.0.tgz",
+      "integrity": "sha512-/0d2YTn8ZFVpIPAU230S9ZLF8WDkSSRWvh/UOLM7zzvkCchum1TtouRgyV8OfgOaYilSGU4lSSqzwBXJVlAwUw==",
+      "requires": {
+        "es5-ext": "^0.10.46"
+      }
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -1911,6 +2008,11 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@babel/core": "^7.10.4",
     "flags": "^0.1.3",
     "htmlparser2": "^4.1.0",
+    "log": "^6.0.0",
     "posthtml": "^0.13.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "dependencies": {
     "@babel/core": "^7.10.4",
+    "debug": "^4.1.1",
     "flags": "^0.1.3",
     "htmlparser2": "^4.1.0",
-    "log": "^6.0.0",
     "posthtml": "^0.13.1"
   },
   "devDependencies": {

--- a/src/injectScripts.js
+++ b/src/injectScripts.js
@@ -1,12 +1,18 @@
 'use strict';
-
 const fs = require('fs');
 const posthtml = require('posthtml');
 
+const DOCTYPE = '!DOCTYPE';
+const HEAD = 'head';
+const HTML = 'html';
 const SCRIPT = 'script';
+const TITLE = 'title';
+
+const JS_TEST = 'js-test.js';
 const TEST_HARNESS = 'testharness.js';
 const TEST_HARNESS_REPORT = 'testharnessreport.js';
-const JS_TEST = 'js-test.js';
+
+const INDENTATION_REGEX = new RegExp('^\n[ ]*$');
 
 function replaceScriptsPlugin(params) {
   return function(tree) {
@@ -30,7 +36,6 @@ function changeSrcPlugin() {
     tree.match({tag: SCRIPT}, (node) => {
       if (node.attrs && node.attrs.src && node.attrs.src.endsWith(JS_TEST)) {
         node.attrs.src = node.attrs.src.replace(JS_TEST, TEST_HARNESS);
-
         srcPath = node.attrs.src;
       }
       return node;
@@ -42,7 +47,52 @@ function changeSrcPlugin() {
     };
 
     addNode(tree, newSrcNode, (node) => {
-      return node.tag == SCRIPT && node.attrs && node.attrs.src == srcPath;
+      return node.tag === SCRIPT && node.attrs && node.attrs.src === srcPath;
+    });
+  };
+}
+
+// insertTitlePlugin will add <title>description</title> in the following
+// order of precedence if present:
+// will not add if a <title> exists already,
+// immediately after the <head> tag,
+// immediately after the <html> tag,
+// immediately after the <!DOCTYPE html> tag,
+// at the beginning of the document.
+function insertTitlePlugin(description) {
+  return function(tree) {
+    let foundTitle = false;
+    tree.match({tag: TITLE}, (node) => {
+      console.log('WARNING: existing <title>, not using description paramter.');
+      foundTitle = true;
+      return node;
+    });
+    if (foundTitle) {
+      return;
+    }
+    const newTitleNode = {
+      tag: TITLE,
+      content: [description],
+    };
+
+    if (addNodeWithinTag(tree, newTitleNode, (node) => {
+      return node.tag === HEAD;
+    })) {
+      return;
+    }
+    if (addNodeWithinTag(tree, newTitleNode, (node) => {
+      return node.tag === HTML;
+    })) {
+      return;
+    }
+    if (addNode(tree, newTitleNode, (node) => {
+      return typeof node === 'string' && node.includes(DOCTYPE);
+    })) {
+      return;
+    }
+    // Default: add title to beginning of document
+    addNode(tree, newTitleNode, () => {
+      return true;
     });
   };
 }
@@ -52,10 +102,14 @@ function changeSrcPlugin() {
 // https://github.com/posthtml/posthtml/blob/master/lib/api.js#L102
 // returns true if node was added, false if not.
 function addNode(tree, node, conditionTest) {
+  let indentation = '\n';
   if (Array.isArray(tree)) {
     for (let i = 0; i < tree.length; i++) {
-      if (typeof tree[i] == 'object' && conditionTest(tree[i])) {
-        tree.splice(i+1, 0, '\n');
+      if (typeof tree[i] === 'string' && INDENTATION_REGEX.test(tree[i])) {
+        indentation = tree[i];
+      }
+      if (conditionTest(tree[i])) {
+        tree.splice(i+1, 0, indentation);
         tree.splice(i+2, 0, node);
         return true;
       }
@@ -64,18 +118,56 @@ function addNode(tree, node, conditionTest) {
       }
     }
   } else if (typeof tree === 'object' && tree.hasOwnProperty('content')) {
-    addNode(tree.content, node, conditionTest);
+    return addNode(tree.content, node, conditionTest);
   }
 
   return false;
 }
 
-function injectScriptsIntoHTML(filePath, scripts, outputPath) {
+// Adds node after the first node that returns true on conditionTest
+// This function is based on posthtml's traverse() function.
+// https://github.com/posthtml/posthtml/blob/master/lib/api.js#L102
+// returns true if node was added, false if not.
+function addNodeWithinTag(tree, node, conditionTest) {
+  let indentation = '\n';
+  if (Array.isArray(tree)) {
+    for (let i = 0; i < tree.length; i++) {
+      if (typeof tree[i] === 'string' && INDENTATION_REGEX.test(tree[i])) {
+        indentation = tree[i];
+      }
+      if (conditionTest(tree[i])) {
+        if (typeof tree[i] === 'object') {
+          const content = tree[i].content ? tree[i].content : [];
+          if (tree[i].content.length > 0 && typeof tree[i].content[0] === 'string' && INDENTATION_REGEX.test(tree[i].content[0])) {
+            indentation = tree[i].content[0];
+          }
+          content.unshift(node);
+          content.unshift(indentation);
+          tree[i].content = content;
+          return true;
+        }
+        tree.splice(i+1, 0, indentation);
+        tree.splice(i+2, 0, node);
+        return true;
+      }
+      if (addNodeWithinTag(tree[i], node, conditionTest)) {
+        return true;
+      }
+    }
+  } else if (typeof tree === 'object' && tree.hasOwnProperty('content')) {
+    return addNodeWithinTag(tree.content, node, conditionTest);
+  }
+
+  return false;
+}
+
+function injectScriptsIntoHTML(filePath, scripts, description, outputPath) {
   const oldHTML = fs.readFileSync(filePath, 'utf-8');
 
   const newHTML = posthtml([
     replaceScriptsPlugin({filePath: filePath, scripts: scripts}),
     changeSrcPlugin(),
+    insertTitlePlugin(description),
   ])
       .process(oldHTML, {sync: true})
       .html;

--- a/src/injectScripts.js
+++ b/src/injectScripts.js
@@ -1,4 +1,5 @@
 'use strict';
+const debug = require('debug');
 const fs = require('fs');
 const posthtml = require('posthtml');
 
@@ -13,6 +14,8 @@ const TEST_HARNESS = 'testharness.js';
 const TEST_HARNESS_REPORT = 'testharnessreport.js';
 
 const INDENTATION_REGEX = /^\n\s*$/g;
+
+const log = debug('injectScripts');
 
 function replaceScriptsPlugin(params) {
   return function(tree) {
@@ -70,7 +73,7 @@ function insertTitlePlugin(description) {
     });
     // <title> exists, don't add a new one.
     if (foundTitle) {
-      console.log('WARNING: existing <title>, not using description parameter');
+      log('WARNING: existing <title>, not using description parameter');
       return;
     }
     const newTitleNode = {
@@ -86,7 +89,7 @@ function insertTitlePlugin(description) {
     if (addNodeWithinTag(tree, newTitleNode, (node) => node.tag === HTML)) {
       return;
     }
-    // Within <!DOCTYPE html> tag
+    // After <!DOCTYPE html> tag
     if (addNode(tree, newTitleNode, (node) =>
       typeof node === 'string' && node.includes(DOCTYPE))
     ) {

--- a/src/injectScripts.js
+++ b/src/injectScripts.js
@@ -12,7 +12,7 @@ const JS_TEST = 'js-test.js';
 const TEST_HARNESS = 'testharness.js';
 const TEST_HARNESS_REPORT = 'testharnessreport.js';
 
-const INDENTATION_REGEX = new RegExp('^\n[ ]*$');
+const INDENTATION_REGEX = /^\n\s*$/g;
 
 function replaceScriptsPlugin(params) {
   return function(tree) {

--- a/src/injectScripts.js
+++ b/src/injectScripts.js
@@ -79,27 +79,21 @@ function insertTitlePlugin(description) {
     };
 
     // Within <head> tag
-    if (addNodeWithinTag(tree, newTitleNode, (node) => {
-      return node.tag === HEAD;
-    })) {
+    if (addNodeWithinTag(tree, newTitleNode, (node) => node.tag === HEAD)) {
       return;
     }
     // Within <html> tag
-    if (addNodeWithinTag(tree, newTitleNode, (node) => {
-      return node.tag === HTML;
-    })) {
+    if (addNodeWithinTag(tree, newTitleNode, (node) => node.tag === HTML)) {
       return;
     }
     // Within <!DOCTYPE html> tag
-    if (addNode(tree, newTitleNode, (node) => {
-      return typeof node === 'string' && node.includes(DOCTYPE);
-    })) {
+    if (addNode(tree, newTitleNode, (node) =>
+      typeof node === 'string' && node.includes(DOCTYPE))
+    ) {
       return;
     }
     // Default: add title to beginning of document
-    addNode(tree, newTitleNode, () => {
-      return true;
-    });
+    addNode(tree, newTitleNode, () => true);
   };
 }
 

--- a/src/transform.js
+++ b/src/transform.js
@@ -179,7 +179,7 @@ function removeDebug() {
 // Applies transformations in pluginArray to sourceCode (string)
 // If addSetup is true, will add setup() test call at the beginning of
 // the script.
-// Returns an object 
+// Returns an object
 //  - code {string}: the transformed source code string
 //  - title {string}: test title string, if parsed from description() calls
 function transformSourceCodeString(sourceCode, addSetup=true) {

--- a/src/transform.js
+++ b/src/transform.js
@@ -179,8 +179,9 @@ function removeDebug() {
 // Applies transformations in pluginArray to sourceCode (string)
 // If addSetup is true, will add setup() test call at the beginning of
 // the script.
-// Returns an object with the transformed source code and the test title,
-// if one was parsed from description() calls.
+// Returns an object 
+//  - code {string}: the transformed source code string
+//  - title {string}: test title string, if parsed from description() calls
 function transformSourceCodeString(sourceCode, addSetup=true) {
   // transformInfo is an object to be passed to plugins that return closures
   // so that we can have access to data within the transformation back in this

--- a/src/transform.js
+++ b/src/transform.js
@@ -140,6 +140,9 @@ function transformShouldBeEqualToSpecific() {
   };
 }
 
+// Returns a closure that modifies the parameter, transformInfo
+// so that information gathered during traversal can be used in
+// the outer scope.
 function removeDescription(transformInfo) {
   return function() {
     return {
@@ -157,7 +160,7 @@ function removeDescription(transformInfo) {
   };
 }
 
-
+// TODO: maybe change debug() to console.log() instead of deleting?
 function removeDebug() {
   return {
     visitor: {
@@ -170,8 +173,14 @@ function removeDebug() {
   };
 }
 
+// Applies transformations in pluginArray to sourceCode (string)
+// If addSetup is true, will add setup() test call at the beginning of
+// the script.
+// Returns an object with the transformed source code and the test title,
+// if one was parsed from description() calls.
 function transformSourceCodeString(sourceCode, addSetup=true) {
   const transformInfo = {};
+  // Upon visiting a node, babel runs each plugin in order.
   const pluginArray = [
     transformShouldBeBool,
     transformShouldBeValue,
@@ -191,6 +200,5 @@ function transformSourceCodeString(sourceCode, addSetup=true) {
 
   return {code: output.code, title: transformInfo.description};
 }
-
 
 module.exports = {transformSourceCodeString};

--- a/src/transform.js
+++ b/src/transform.js
@@ -143,7 +143,7 @@ function transformShouldBeEqualToSpecific() {
 // Returns a closure that modifies the parameter, transformInfo
 // so that information gathered during traversal can be used in
 // the outer scope.
-function removeDescription(transformInfo) {
+function removeDescriptionFactory(transformInfo) {
   return function() {
     return {
       visitor: {
@@ -182,6 +182,9 @@ function removeDebug() {
 // Returns an object with the transformed source code and the test title,
 // if one was parsed from description() calls.
 function transformSourceCodeString(sourceCode, addSetup=true) {
+  // transformInfo is an object to be passed to plugins that return closures
+  // so that we can have access to data within the transformation back in this
+  // scope.
   const transformInfo = {};
   // Upon visiting a node, babel runs each plugin in order.
   const pluginArray = [
@@ -189,7 +192,7 @@ function transformSourceCodeString(sourceCode, addSetup=true) {
     transformShouldBeValue,
     transformShouldBeComparator,
     transformShouldBeEqualToSpecific,
-    removeDescription(transformInfo),
+    removeDescriptionFactory(transformInfo),
     removeDebug,
   ];
 

--- a/src/transform.js
+++ b/src/transform.js
@@ -149,9 +149,12 @@ function removeDescription(transformInfo) {
       visitor: {
         CallExpression(path) {
           if (path.node.callee.name === 'description') {
-            // TODO: this currently will overwrite with the last description.
-            // Later, we might only want the first or a concatenation.
-            transformInfo.description = path.node.arguments[0].value;
+            // This will currently only take the first description.
+            // We might want to change to use the last, longest, or a
+            // concatenation?
+            if (!transformInfo.description) {
+              transformInfo.description = path.node.arguments[0].value;
+            }
             path.remove();
           }
         },

--- a/test/testInjectScripts.js
+++ b/test/testInjectScripts.js
@@ -11,11 +11,12 @@ describe('#injectScriptsIntoHTML', function() {
   context('Inject 2 Scripts', function() {
     const tmpFile = tmp.fileSync();
     const testFile = './test/testdata/input/file-list-test.html';
+    const testDescription = 'This test tests some stuff in the browser';
     const scripts = [];
     scripts.push(fs.readFileSync('./test/testdata/reference/transformed_script0_file-list-test.js', 'utf-8'));
     scripts.push(fs.readFileSync('./test/testdata/reference/transformed_script1_file-list-test.js', 'utf-8'));
 
-    const actualHTML = injectScriptsIntoHTML(testFile, scripts, tmpFile.name);
+    const actualHTML = injectScriptsIntoHTML(testFile, scripts, testDescription, tmpFile.name);
     const expectedHTML = fs.readFileSync('./test/testdata/reference/transformed_file-list-test.html', 'utf-8');
 
     it('should return the correct HTML', function() {
@@ -25,6 +26,60 @@ describe('#injectScriptsIntoHTML', function() {
     it('should write a file with the html', function() {
       const actualFileContents = fs.readFileSync(tmpFile.name, 'utf-8');
       assert.equal(actualFileContents, expectedHTML);
+    });
+  });
+
+
+  context('Insert <title> tags in the correct place', function() {
+    it('should insert <title> after <head>', function() {
+      const tmpFile = tmp.fileSync();
+      const testFile = './test/testdata/input/indented-head-tag.html';
+      const testDescription = 'Testing to see if title indented in transformed HTML';
+      const scripts = ['', ''];
+      const actualHTML = injectScriptsIntoHTML(testFile, scripts, testDescription, tmpFile.name);
+      const expectedHTML = fs.readFileSync('./test/testdata/reference/transformed_indented-head-tag.html', 'utf-8');
+      assert.equal(actualHTML, expectedHTML);
+    });
+
+    it('should insert <title> after <html>', function() {
+      const tmpFile = tmp.fileSync();
+      const testFile = './test/testdata/input/canvas-description-and-role.html';
+      const testDescription = 'This test makes sure that a canvas with and without fallback content each has the right role and description.';
+      const scripts = [''];
+      scripts.push(fs.readFileSync('./test/testdata/reference/transformed_script1_canvas-description-and-role.js', 'utf-8'));
+      const actualHTML = injectScriptsIntoHTML(testFile, scripts, testDescription, tmpFile.name);
+      const expectedHTML = fs.readFileSync('./test/testdata/reference/transformed_canvas-description-and-role.html', 'utf-8');
+      assert.equal(actualHTML, expectedHTML);
+    });
+
+    it('should insert <title> after <!DOCTYPE html>', function() {
+      const tmpFile = tmp.fileSync();
+      const testFile = './test/testdata/input/doctype-title.html';
+      const testDescription = 'Testing to see if title under DOCTYPE in transformed HTML';
+      const scripts = ['', ''];
+      const actualHTML = injectScriptsIntoHTML(testFile, scripts, testDescription, tmpFile.name);
+      const expectedHTML = fs.readFileSync('./test/testdata/reference/transformed_doctype-title.html');
+      assert.equal(actualHTML, expectedHTML);
+    });
+
+    it('should insert <title> at beginning of document', function() {
+      const tmpFile = tmp.fileSync();
+      const testFile = './test/testdata/input/module-script.html';
+      const testDescription = 'Test basic module execution.';
+      const scripts = ['', '', '', ''];
+      const actualHTML = injectScriptsIntoHTML(testFile, scripts, testDescription, tmpFile.name);
+      const expectedHTML = fs.readFileSync('./test/testdata/reference/transformed_module-script.html', 'utf-8');
+      assert.equal(actualHTML, expectedHTML);
+    });
+
+    it('should NOT insert <title> if already present', function() {
+      const tmpFile = tmp.fileSync();
+      const testFile = './test/testdata/input/file-writer-truncate-extend.html';
+      const testDescription = 'description that should NOT be present';
+      const scripts = ['', '', ''];
+      const actualHTML = injectScriptsIntoHTML(testFile, scripts, testDescription, tmpFile.name);
+      const expectedHTML = fs.readFileSync('./test/testdata/reference/transformed_file-writer-truncate-extend.html', 'utf-8');
+      assert.equal(actualHTML, expectedHTML);
     });
   });
 });

--- a/test/testInjectScripts.js
+++ b/test/testInjectScripts.js
@@ -11,7 +11,7 @@ describe('#injectScriptsIntoHTML', function() {
   context('Inject 2 Scripts', function() {
     const tmpFile = tmp.fileSync();
     const testFile = './test/testdata/input/file-list-test.html';
-    const testDescription = 'This test tests some stuff in the browser';
+    const testDescription = 'Test the attribute of FileList';
     const scripts = [];
     scripts.push(fs.readFileSync('./test/testdata/reference/transformed_script0_file-list-test.js', 'utf-8'));
     scripts.push(fs.readFileSync('./test/testdata/reference/transformed_script1_file-list-test.js', 'utf-8'));

--- a/test/testTransform.js
+++ b/test/testTransform.js
@@ -130,17 +130,21 @@ describe('#testTransformSourceCode()', function() {
     it('should transform short file, adding setup()', function() {
       const inputFile = './test/testdata/input/short_file.js';
       const sourceCode = fs.readFileSync(inputFile, 'utf-8');
-      const expected = fs.readFileSync('./test/testdata/reference/transformed_short_file.js', 'utf-8');
-      const actual = transformSourceCodeString(sourceCode).code;
-      assert.equal(actual, expected);
+      const expectedCode = fs.readFileSync('./test/testdata/reference/transformed_short_file.js', 'utf-8');
+      const expectedTitle = 'Makes sure typeof works';
+      const actual = transformSourceCodeString(sourceCode);
+      assert.equal(actual.code, expectedCode);
+      assert.equal(actual.title, expectedTitle);
     });
 
     it('should transform multi-line file with varying parameter expressions', function() {
       const inputFile = './test/testdata/input/multiline_file.js';
       const sourceCode = fs.readFileSync(inputFile, 'utf-8');
-      const expected = fs.readFileSync('./test/testdata/reference/transformed_multiline_file.js', 'utf-8');
-      const actual = transformSourceCodeString(sourceCode).code;
-      assert.equal(actual, expected);
+      const expectedCode = fs.readFileSync('./test/testdata/reference/transformed_multiline_file.js', 'utf-8');
+      const expectedTitle = 'Tests value and testObject';
+      const actual = transformSourceCodeString(sourceCode);
+      assert.equal(actual.code, expectedCode);
+      assert.equal(actual.title, expectedTitle);
     });
   });
 });

--- a/test/testTransform.js
+++ b/test/testTransform.js
@@ -9,119 +9,119 @@ describe('#testTransformSourceCode()', function() {
     it('should NOT transform non js-test.js functions', function() {
       const inputString = 'const x = myHelperMethod(param1);';
       const expected = 'const x = myHelperMethod(param1);';
-      const actual = transformSourceCodeString(inputString, false);
+      const actual = transformSourceCodeString(inputString, false).code;
       assert.equal(actual, expected);
     });
 
     it('should transform shouldBeTrue()', function() {
       const inputString = 'shouldBeTrue("foo()");';
       const expected = 'assert_true(foo());';
-      const actual = transformSourceCodeString(inputString, false);
+      const actual = transformSourceCodeString(inputString, false).code;
       assert.equal(actual, expected);
     });
 
     it('should transform shouldBeFalse()', function() {
       const inputString = 'shouldBeFalse("foo(param1, param2) && fakeBool");';
       const expected = 'assert_false(foo(param1, param2) && fakeBool);';
-      const actual = transformSourceCodeString(inputString, false);
+      const actual = transformSourceCodeString(inputString, false).code;
       assert.equal(actual, expected);
     });
 
     it('should transform shouldBeNull()', function() {
       const inputString = 'shouldBeNull("fakeArray[0].value");';
       const expected = 'assert_equals(fakeArray[0].value, null);';
-      const actual = transformSourceCodeString(inputString, false);
+      const actual = transformSourceCodeString(inputString, false).code;
       assert.equal(actual, expected);
     });
 
     it('should transform shouldBeNaN()', function() {
       const inputString = 'shouldBeNaN("zero / 0");';
       const expected = 'assert_equals(zero / 0, NaN);';
-      const actual = transformSourceCodeString(inputString, false);
+      const actual = transformSourceCodeString(inputString, false).code;
       assert.equal(actual, expected);
     });
 
     it('should transform shouldBeZero()', function() {
       const inputString = 'shouldBeZero("1 - 1");';
       const expected = 'assert_equals(1 - 1, 0);';
-      const actual = transformSourceCodeString(inputString, false);
+      const actual = transformSourceCodeString(inputString, false).code;
       assert.equal(actual, expected);
     });
 
     it('should transform shouldBeEmptyString()', function() {
       const inputString = 'shouldBeEmptyString("component.Name");';
       const expected = 'assert_equals(component.Name, "");';
-      const actual = transformSourceCodeString(inputString, false);
+      const actual = transformSourceCodeString(inputString, false).code;
       assert.equal(actual, expected);
     });
 
     it('should transform shouldBeUndefined()', function() {
       const inputString = 'shouldBeUndefined("typeof badVariable");';
       const expected = 'assert_equals(typeof badVariable, undefined);';
-      const actual = transformSourceCodeString(inputString, false);
+      const actual = transformSourceCodeString(inputString, false).code;
       assert.equal(actual, expected);
     });
 
     it('should transform shouldBeNonZero()', function() {
       const inputString = 'shouldBeNonZero("nested[1][index] % 3");';
       const expected = 'assert_not_equals(nested[1][index] % 3, 0);';
-      const actual = transformSourceCodeString(inputString, false);
+      const actual = transformSourceCodeString(inputString, false).code;
       assert.equal(actual, expected);
     });
 
     it('should transform shouldBeNonNull()', function() {
       const inputString = 'shouldBeNonNull("Library.call()");';
       const expected = 'assert_not_equals(Library.call(), null);';
-      const actual = transformSourceCodeString(inputString, false);
+      const actual = transformSourceCodeString(inputString, false).code;
       assert.equal(actual, expected);
     });
 
     it('should transform shouldBeDefined()', function() {
       const inputString = 'shouldBeDefined("obj.property.good.valid.defined");';
       const expected = 'assert_not_equals(obj.property.good.valid.defined, undefined);';
-      const actual = transformSourceCodeString(inputString, false);
+      const actual = transformSourceCodeString(inputString, false).code;
       assert.equal(actual, expected);
     });
 
     it('should transform shouldBe()', function() {
       const inputString = 'shouldBe("first_expression1()", "expectedResult.evaluate().name");';
       const expected = 'assert_equals(first_expression1(), expectedResult.evaluate().name);';
-      const actual = transformSourceCodeString(inputString, false);
+      const actual = transformSourceCodeString(inputString, false).code;
       assert.equal(actual, expected);
     });
 
     it('should transform shouldNotBe()', function() {
       const inputString = 'shouldNotBe("file instanceof \'number\'", "true === true");';
       const expected = 'assert_not_equals(file instanceof \'number\', true === true);';
-      const actual = transformSourceCodeString(inputString, false);
+      const actual = transformSourceCodeString(inputString, false).code;
       assert.equal(actual, expected);
     });
 
     it('should transform shouldBeGreaterThan()', function() {
       const inputString = 'shouldBeGreaterThan("testValue", "smallValue");';
       const expected = 'assert_greater_than(testValue, smallValue);';
-      const actual = transformSourceCodeString(inputString, false);
+      const actual = transformSourceCodeString(inputString, false).code;
       assert.equal(actual, expected);
     });
 
     it('should transform shouldBeGreaterThanOrEqualTo()', function() {
       const inputString = 'shouldBeGreaterThanOrEqualTo("test().function()()()", "smallerValue");';
       const expected = 'assert_greater_than_equal(test().function()()(), smallerValue);';
-      const actual = transformSourceCodeString(inputString, false);
+      const actual = transformSourceCodeString(inputString, false).code;
       assert.equal(actual, expected);
     });
 
     it('should transform shouldBeEqualToString()', function() {
       const inputString = 'shouldBeEqualToString("\'string\' + \'string\'", "stringstring");';
       const expected = 'assert_equals(\'string\' + \'string\', "stringstring");';
-      const actual = transformSourceCodeString(inputString, false);
+      const actual = transformSourceCodeString(inputString, false).code;
       assert.equal(actual, expected);
     });
 
     it('should transform shouldBeEqualToNumber()', function() {
       const inputString = 'shouldBeEqualToNumber("pixel.location - 1", 25);';
       const expected = 'assert_equals(pixel.location - 1, 25);';
-      const actual = transformSourceCodeString(inputString, false);
+      const actual = transformSourceCodeString(inputString, false).code;
       assert.equal(actual, expected);
     });
   });
@@ -131,7 +131,7 @@ describe('#testTransformSourceCode()', function() {
       const inputFile = './test/testdata/input/short_file.js';
       const sourceCode = fs.readFileSync(inputFile, 'utf-8');
       const expected = fs.readFileSync('./test/testdata/reference/transformed_short_file.js', 'utf-8');
-      const actual = transformSourceCodeString(sourceCode);
+      const actual = transformSourceCodeString(sourceCode).code;
       assert.equal(actual, expected);
     });
 
@@ -139,7 +139,7 @@ describe('#testTransformSourceCode()', function() {
       const inputFile = './test/testdata/input/multiline_file.js';
       const sourceCode = fs.readFileSync(inputFile, 'utf-8');
       const expected = fs.readFileSync('./test/testdata/reference/transformed_multiline_file.js', 'utf-8');
-      const actual = transformSourceCodeString(sourceCode); ;
+      const actual = transformSourceCodeString(sourceCode).code;
       assert.equal(actual, expected);
     });
   });

--- a/test/testdata/input/canvas-description-and-role.html
+++ b/test/testdata/input/canvas-description-and-role.html
@@ -1,0 +1,40 @@
+<!--
+    This file was exactly copied below from
+    /third_party/blink/web_tests/accessibility/canvas-description-and-role.html
+    in order to test the code with real examples of legacy tests.
+-->
+<!DOCTYPE HTML>
+<html>
+<body>
+<script src="../resources/js-test.js"></script>
+
+<style>canvas { display: inline; border: 1px solid #000; }</style>
+    <!-- No whitespace between canvases on purpose, so there's the same
+         number of children of the container element on all platforms. -->
+    <div id="container" tabIndex=0 aria-label="Container"><canvas id="canvas1" width="100" height="100" aria-label="Canvas label">Fallback text</canvas><canvas id="canvas2" width="100" height="100"><button>Inner button</button></canvas><canvas id="canvas3-skipped" width="100" height="100"></canvas></div>
+
+<div id="console"></div>
+<script>
+description("This test makes sure that a canvas with and without fallback content each has the right role and description.")
+
+if (window.testRunner && window.accessibilityController) {
+    testRunner.dumpAsText();
+
+    document.getElementById('container').focus();
+    var axContainer = accessibilityController.focusedElement;
+
+    shouldBe("axContainer.childrenCount", "2");
+
+    var axCanvas1 = axContainer.childAtIndex(0);
+    debug('Canvas 1 description: ' + axCanvas1.name);
+    debug('Canvas 1 role: ' + axCanvas1.role);
+
+    var axCanvas2 = axContainer.childAtIndex(1);
+    debug('Canvas 2 description: ' + axCanvas2.name);
+    debug('Canvas 2 role: ' + axCanvas2.role);
+}
+
+</script>
+
+</body>
+</html>

--- a/test/testdata/input/doctype-title.html
+++ b/test/testdata/input/doctype-title.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<script src="../../../resources/js-test.js"></script>
+<script>
+description("Testing to see if title under DOCTYPE in transformed HTML");
+</script>

--- a/test/testdata/input/file-writer-truncate-extend.html
+++ b/test/testdata/input/file-writer-truncate-extend.html
@@ -1,0 +1,18 @@
+<!--
+    This file was exactly copied below from
+    /third_party/blink/web_tests/fast/filesystem/file-writer-truncate-extend.html
+    in order to test the code with real examples of legacy tests.
+-->
+<!DOCTYPE HTML>
+<html>
+ <head>
+    <title>File Writer Truncate-To-Extend</title>
+    <script src="../../resources/js-test.js"></script>
+    <script src="resources/file-writer-utils.js"></script>
+ </head>
+ <body>
+    <div id="description"></div>
+    <div id="console"></div>
+    <script src="resources/file-writer-truncate-extend.js"></script>
+ </body>
+</html>

--- a/test/testdata/input/indented-head-tag.html
+++ b/test/testdata/input/indented-head-tag.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Testing to see if title indented in transformed HTML");
+</script>
+</body>
+</html>

--- a/test/testdata/input/module-script.html
+++ b/test/testdata/input/module-script.html
@@ -1,0 +1,15 @@
+<!--
+    This file was exactly copied below from
+    /third_party/blink/web_tests/fast/dom/HTMLScriptElement/module-script.html
+    in order to test the code with real examples of legacy tests.
+-->
+<script src="../../../resources/js-test.js"></script>
+<script>
+description("Test basic module execution.");
+</script>
+<script type="module">
+debug("Module scripts should be executed...");
+</script>
+<script type="module" language="nonsense">
+debug("...and should ignore any 'language' attribute");
+</script>

--- a/test/testdata/input/multiline_file.js
+++ b/test/testdata/input/multiline_file.js
@@ -1,3 +1,4 @@
+description('Tests value and testObject');
 const value = 'value';
 const badValue = 1;
 shouldBeEqualToString("value", 'value');
@@ -6,5 +7,6 @@ let testObject = {
   property: true
 };
 
+description('This part tests testObject but this is a bad description!');
 shouldBeDefined("testObject.property");
 shouldBeTrue("testObject.property");

--- a/test/testdata/input/short_file.js
+++ b/test/testdata/input/short_file.js
@@ -1,1 +1,2 @@
+description('Makes sure typeof works');
 shouldBe("typeof nameVar", "'string'");

--- a/test/testdata/reference/transformed_canvas-description-and-role.html
+++ b/test/testdata/reference/transformed_canvas-description-and-role.html
@@ -1,0 +1,36 @@
+<!--
+    This file was exactly copied below from
+    /third_party/blink/web_tests/accessibility/canvas-description-and-role.html
+    in order to test the code with real examples of legacy tests.
+-->
+<!DOCTYPE HTML>
+<html>
+<title>This test makes sure that a canvas with and without fallback content each has the right role and description.</title>
+<body>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+
+<style>canvas { display: inline; border: 1px solid #000; }</style>
+    <!-- No whitespace between canvases on purpose, so there's the same
+         number of children of the container element on all platforms. -->
+    <div id="container" tabIndex="0" aria-label="Container"><canvas id="canvas1" width="100" height="100" aria-label="Canvas label">Fallback text</canvas><canvas id="canvas2" width="100" height="100"><button>Inner button</button></canvas><canvas id="canvas3-skipped" width="100" height="100"></canvas></div>
+
+<div id="console"></div>
+<script>
+
+if (window.testRunner && window.accessibilityController) {
+    testRunner.dumpAsText();
+
+    document.getElementById('container').focus();
+    var axContainer = accessibilityController.focusedElement;
+
+    assert_equals(axContainer.childrenCount, 2);
+
+    var axCanvas1 = axContainer.childAtIndex(0);
+
+    var axCanvas2 = axContainer.childAtIndex(1);
+}
+</script>
+
+</body>
+</html>

--- a/test/testdata/reference/transformed_doctype-title.html
+++ b/test/testdata/reference/transformed_doctype-title.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<title>Testing to see if title under DOCTYPE in transformed HTML</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script>
+</script>

--- a/test/testdata/reference/transformed_file-list-test.html
+++ b/test/testdata/reference/transformed_file-list-test.html
@@ -6,7 +6,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>This test tests some stuff in the browser</title>
+<title>Test the attribute of FileList</title>
 <script src="../../resources/testharness.js"></script>
 <script src="../../resources/testharnessreport.js"></script>
 </head>

--- a/test/testdata/reference/transformed_file-list-test.html
+++ b/test/testdata/reference/transformed_file-list-test.html
@@ -6,6 +6,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<title>This test tests some stuff in the browser</title>
 <script src="../../resources/testharness.js"></script>
 <script src="../../resources/testharnessreport.js"></script>
 </head>
@@ -18,8 +19,6 @@ setup({
   single_test: true,
   explicit_done: false
 });
-description("Test the attribute of FileList.");
-debug("Start");
 
 function onInputFileChange(files) {
   window.files = files;

--- a/test/testdata/reference/transformed_file-writer-truncate-extend.html
+++ b/test/testdata/reference/transformed_file-writer-truncate-extend.html
@@ -1,0 +1,19 @@
+<!--
+    This file was exactly copied below from
+    /third_party/blink/web_tests/fast/filesystem/file-writer-truncate-extend.html
+    in order to test the code with real examples of legacy tests.
+-->
+<!DOCTYPE HTML>
+<html>
+ <head>
+    <title>File Writer Truncate-To-Extend</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script src="resources/file-writer-utils.js"></script>
+ </head>
+ <body>
+    <div id="description"></div>
+    <div id="console"></div>
+    <script src="resources/file-writer-truncate-extend.js"></script>
+ </body>
+</html>

--- a/test/testdata/reference/transformed_indented-head-tag.html
+++ b/test/testdata/reference/transformed_indented-head-tag.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Testing to see if title indented in transformed HTML</title>
+  <script src="../../../resources/testharness.js"></script>
+  <script src="../../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+</script>
+</body>
+</html>

--- a/test/testdata/reference/transformed_module-script.html
+++ b/test/testdata/reference/transformed_module-script.html
@@ -1,0 +1,14 @@
+<!--
+    This file was exactly copied below from
+    /third_party/blink/web_tests/fast/dom/HTMLScriptElement/module-script.html
+    in order to test the code with real examples of legacy tests.
+-->
+<title>Test basic module execution.</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script>
+</script>
+<script type="module">
+</script>
+<script type="module" language="nonsense">
+</script>

--- a/test/testdata/reference/transformed_script1_canvas-description-and-role.js
+++ b/test/testdata/reference/transformed_script1_canvas-description-and-role.js
@@ -1,0 +1,13 @@
+
+if (window.testRunner && window.accessibilityController) {
+    testRunner.dumpAsText();
+
+    document.getElementById('container').focus();
+    var axContainer = accessibilityController.focusedElement;
+
+    assert_equals(axContainer.childrenCount, 2);
+
+    var axCanvas1 = axContainer.childAtIndex(0);
+
+    var axCanvas2 = axContainer.childAtIndex(1);
+}

--- a/test/testdata/reference/transformed_script1_file-list-test.js
+++ b/test/testdata/reference/transformed_script1_file-list-test.js
@@ -2,8 +2,6 @@ setup({
   single_test: true,
   explicit_done: false
 });
-description("Test the attribute of FileList.");
-debug("Start");
 
 function onInputFileChange(files) {
   window.files = files;


### PR DESCRIPTION
This is a large PR, but mostly due to test changes and input/reference file additions. 
The source code now removes the description() and debug() calls in transform.js, returning the first description() string as a title.
That string is then passed to injectScripts.js and inserted as a `<title>` node, following an order of precedence on location. This includes a new insertion process for adding a node within other tags like `<head>` and `<html>`. There is an associated test for each location a `<title>` can go.
The insertion functions insertNode and insertNodeWithinTag try to correctly indent the new node based on the surrounding context indentation.
The setup() call is now only added once to the first non-empty script.