### PR TITLE
Recursive directory transformations and .js file transformation support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,7 @@
     },
     "overrides": [
         {
-            "files": ["test/*.js"],
+            "files": ["test/*.js", "index.js"],
             "rules": {
                 "max-len": 0
             }

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
       - [Required Flags](#required-flags)
     - [Examples](#examples)
   - [Functional Overview](#functional-overview)
+  - [Things to Look Out For](#things-to-look-out-for)
   - [Verification](#verification)
     - [All PASS Requirement](#all-pass-requirement)
   - [Issues](#issues)
@@ -73,7 +74,7 @@ appear in that directory with their original names.
 Options:
   --file: Path to test file to transform
     (default: null)
-  --dir: Path to dir of test files to transform
+  --dir: Path to dir of test files and directories to recursively transform
     (default: null)
   --output_dir: Path to dir where output files should be written. If 
     null, will overwrite input files. 
@@ -90,6 +91,8 @@ Options:
 You must specify **exactly one** of `--file` or `--dir`.
 
 ### Examples
+
+See an [example CL in linked bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1120356).
 
 Transforming a directory of tests, running verification with a build called out/Debug
 
@@ -118,7 +121,7 @@ Looking for new crash logs ...
 Summarizing results ...
 The test ran as expected.
 ```
-This is for one file, but for a directory you will see a similar output for each file in the directory.
+This is for one file, but for a directory you will see a similar output for each file in the directory tree.
 At the end of the run for a directory, you will see an output similar to that below. You can then
 search the output for the file paths that fail transformation or verification to see the associated error.
 </details>
@@ -159,8 +162,9 @@ For a file, the tool will attempt to transform that file
 and then attempt to verify that file. No summary output is provided since all the output is related to the single
 file.
 
-For a directory, the tool will iterate through the files in that directory (non-recursively), only transforming
-.html tests. Each file is handled like a single file above (transformed then verified). It is not
+For a directory, the tool will iterate through the files in that directory (recursively), transforming all the .
+js files then all the .html files. Each file is handled like a single file above (transformed then verified). It 
+is not
 batch-transformed then batch-verified. This could lead to problems if files depend on each other, since the
 dependent file might be transformed first and verification would fail.
 After running on a directory, the tool provides summary output detailing the transformations that completed 
@@ -171,10 +175,12 @@ With this summary output, you can manually check files failed transformations/ve
 problem is easily fixed by a human, report bugs with this tool if the transformation should have worked, or just 
 `git checkout` those files and commit the succesful transformations to Gerrit.
 
-The tool currently only transforms .html tests. If a test src's a helper .js script, neither file will be 
-transformed and the test will be marked as skipped. If a test src's a helper .js script __and__ `js-test.js`,
-the test file will be transformed, marked as completed, but verification will fail.
-
+## Things to Look Out For
+For manual review of the transformed tests there are a few common issues that arise.
+- Check the contents of the `<title>` tag, especially if there are helper scripts involved.
+- Style, particularly indentation. 
+- In .js helper scripts, checking whether the file needs `setup()` and `done()` calls if the helper file is
+  the test and not just helper functions
 
 
 ## Verification

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ async function main() {
   }
 
 
-  // The code below is for processing a directory (if --dir) specified.
+  // The code below is for processing a directory (if --dir specified).
   // The tool outputs a summary output on transformation and verification
   // results.
 

--- a/src/transformFile.js
+++ b/src/transformFile.js
@@ -74,6 +74,7 @@ function transformHTMLFile(filePath, outputDir=null) {
     const transformedScripts = [];
     let addSetup = true;
     let title = '';
+    let gc = false;
     const originalScripts = extractScriptsFromHTML(filePath);
     for (let i=0; i < originalScripts.length; i++) {
       const script = originalScripts[i];
@@ -95,6 +96,8 @@ function transformHTMLFile(filePath, outputDir=null) {
       if (title === '' && transformation.title) {
         title = transformation.title;
       }
+
+      gc = gc || transformation.gc;
     }
 
     // This is a defensive check to ensure the transformation didn't lose
@@ -111,7 +114,7 @@ function transformHTMLFile(filePath, outputDir=null) {
       log('Title empty after transformation, using', filePath);
       title = filePath;
     }
-    injectScriptsIntoHTML(filePath, transformedScripts, title, outputPath);
+    injectScriptsIntoHTML(filePath, transformedScripts, title, outputPath, gc);
 
     log('Completed transformation, wrote', outputPath);
     return transformResult.SUCCESS;

--- a/src/transformFile.js
+++ b/src/transformFile.js
@@ -34,7 +34,7 @@ const transformResult = {
 };
 
 /**
- * transformFile performs the full end-to-end transformation of a
+ * transformHTMLFile performs the full end-to-end transformation of a
  * legacy js-test.js HTML test file to use the testharness.js framework.
  * It extracts scripts, transforms them, then puts them back into the HTML,
  * while handling context surrounding the test title and setup() calls.
@@ -46,7 +46,7 @@ const transformResult = {
  *
  * @returns {string (enum from transformResult)} - SUCCESS, SKIP, or FAIL
  */
-function transformFile(filePath, outputDir=null) {
+function transformHTMLFile(filePath, outputDir=null) {
   try {
     // Only support .html tests, don't want to 'transform' something else.
     // This checks the file extension.
@@ -122,6 +122,23 @@ function transformFile(filePath, outputDir=null) {
   }
 }
 
+
+/**
+ * transformJSFile performs the full end-to-end transformation of a
+ * legacy js-test.js helper script to use the testharness.js framework.
+ * It direcly transforms the script and writes the output according
+ * to outputDir below.
+ * NOTE: The script will NOT add the setup() and done() calls as if this
+ * helper script is its own test. They will need to be added manually
+ * if the script is included in a .html file that doesn't have its own test.
+ *
+ * @param {string} filePath - full path to HTML test file to transform
+ * @param {string} outputDir - full path to an existing directory where
+ *  transformed files should be written. If null, overwrites the original
+ *  file. Files in outputDir will have the same name as the original file.
+ *
+ * @returns {string (enum from transformResult)} - SUCCESS, SKIP, or FAIL
+ */
 function transformJsFile(filePath, outputDir=null) {
   try {
     let outputPath;
@@ -133,7 +150,9 @@ function transformJsFile(filePath, outputDir=null) {
     }
 
     const code = fs.readFileSync(filePath, 'utf-8');
-    const transformedCode = transformSourceCodeString(code, true, true).code;
+    // Transform, adding setup() and done(), ignoring the .title property
+    // of returned object.
+    const transformedCode = transformSourceCodeString(code, false, false).code;
 
     fs.writeFileSync(outputPath, transformedCode);
     log('Completed transformation, wrote', outputPath);
@@ -146,4 +165,4 @@ function transformJsFile(filePath, outputDir=null) {
 }
 
 
-module.exports = {transformFile, transformJsFile, transformResult};
+module.exports = {transformHTMLFile, transformJsFile, transformResult};

--- a/src/transformFile.js
+++ b/src/transformFile.js
@@ -92,7 +92,7 @@ function transformFile(filePath, outputDir=null) {
       }
       transformedScripts.push(transformation.code);
       // Use the first title description that appears in the old file.
-      if (title === '') {
+      if (title === '' && transformation.title) {
         title = transformation.title;
       }
     }
@@ -122,7 +122,7 @@ function transformFile(filePath, outputDir=null) {
   }
 }
 
-function transformJSFile(filePath, outputDir=null) {
+function transformJsFile(filePath, outputDir=null) {
   try {
     let outputPath;
     if (outputDir) {
@@ -133,7 +133,7 @@ function transformJSFile(filePath, outputDir=null) {
     }
 
     const code = fs.readFileSync(filePath, 'utf-8');
-    const transformedCode = transformSourceCodeString(code, false, true).code;
+    const transformedCode = transformSourceCodeString(code, true, true).code;
 
     fs.writeFileSync(outputPath, transformedCode);
     log('Completed transformation, wrote', outputPath);
@@ -146,4 +146,4 @@ function transformJSFile(filePath, outputDir=null) {
 }
 
 
-module.exports = {transformFile, transformResult};
+module.exports = {transformFile, transformJsFile, transformResult};

--- a/src/transformFile.js
+++ b/src/transformFile.js
@@ -106,7 +106,7 @@ function transformFile(filePath, outputDir=null) {
     }
 
     // If the title is still undefined after searching scripts for definitions,
-    // use the filepath.
+    // use the filePath.
     if (title === '') {
       log('Title empty after transformation, using', filePath);
       title = filePath;
@@ -117,6 +117,29 @@ function transformFile(filePath, outputDir=null) {
     return transformResult.SUCCESS;
   } catch (err) {
     error('Error while transforming', filePath);
+    error(err);
+    return transformResult.FAIL;
+  }
+}
+
+function transformJSFile(filePath, outputDir=null) {
+  try {
+    let outputPath;
+    if (outputDir) {
+      const fileName = filePath.split('/').pop();
+      outputPath = outputDir + '/' + fileName;
+    } else {
+      outputPath = filePath;
+    }
+
+    const code = fs.readFileSync(filePath, 'utf-8');
+    const transformedCode = transformSourceCodeString(code, false, true).code;
+
+    fs.writeFileSync(outputPath, transformedCode);
+    log('Completed transformation, wrote', outputPath);
+    return transformResult.SUCCESS;
+  } catch (err) {
+    error('Error will transforming js', filePath);
     error(err);
     return transformResult.FAIL;
   }

--- a/src/transformScript.js
+++ b/src/transformScript.js
@@ -177,6 +177,20 @@ function transformImportScriptsArgument() {
   };
 }
 
+function detectGC(transformInfo) {
+  return function() {
+    return {
+      visitor: {
+        CallExpression(path) {
+          if (path.node.callee.name === 'gc') {
+            transformInfo.gc = true;
+          }
+        },
+      },
+    };
+  };
+}
+
 const notTransformed = new Set([
   'evalAndLog',
   'shouldBecomeEqual', 'shouldBecomeEqualToString',
@@ -185,7 +199,6 @@ const notTransformed = new Set([
   'shouldNotThrow', 'shouldThrow',
   'shouldBeNow',
   'expectError', 'shouldHaveHadError',
-  'gc',
   'isSuccessfulyParsed',
   'finishJSTest', 'startWorker',
 ]);
@@ -280,6 +293,7 @@ function transformSourceCodeString(sourceCode, addSetup=true, addDone=true) {
     removeDescriptionFactory(transformInfo),
     transformDebug,
     removeDumpAsText,
+    detectGC(transformInfo),
     reportUntransformedFunctions,
   ];
 
@@ -297,7 +311,11 @@ function transformSourceCodeString(sourceCode, addSetup=true, addDone=true) {
     outputCode += '\ndone();';
   }
 
-  return {code: outputCode, title: transformInfo.description};
+  return {
+    code: outputCode,
+    title: transformInfo.description,
+    gc: transformInfo.gc,
+  };
 }
 
 module.exports = {transformSourceCodeString};

--- a/src/transformScript.js
+++ b/src/transformScript.js
@@ -162,6 +162,21 @@ function transformShouldBeEqualToSpecific() {
   };
 }
 
+function transformImportScriptsArgument() {
+  return {
+    visitor: {
+      CallExpression(path) {
+        if (path.node.callee.name === 'importScripts' &&
+             path.node.arguments[0].value.endsWith('js-test.js')) {
+          // eslint-disable-next-line max-len
+          const newPath = path.node.arguments[0].value.replace('js-test.js', 'testharness.js');
+          path.node.arguments[0] = babel.types.stringLiteral(newPath);
+        }
+      },
+    },
+  };
+}
+
 const notTransformed = new Set([
   'evalAndLog',
   'shouldBecomeEqual', 'shouldBecomeEqualToString',
@@ -261,6 +276,7 @@ function transformSourceCodeString(sourceCode, addSetup=true, addDone=true) {
     transformShouldBeComparator,
     transformShouldBeEqualToSpecific,
     transformShouldBeType,
+    transformImportScriptsArgument,
     removeDescriptionFactory(transformInfo),
     transformDebug,
     removeDumpAsText,

--- a/test/testTransformFile.js
+++ b/test/testTransformFile.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const tmp = require('tmp');
 tmp.setGracefulCleanup();
 
-const {transformFile, transformResult} = require('../src/transformFile.js');
+const {transformHTMLFile, transformResult} = require('../src/transformFile.js');
 
 describe('#transformFile', function() {
   let tmpDir;
@@ -20,7 +20,7 @@ describe('#transformFile', function() {
     it('should transform file-list-test.html and write output file', function() {
       const inputFile = './test/testdata/input/file-list-test.html';
       const referenceFile = './test/testdata/reference/transformed_file-list-test.html';
-      const result = transformFile(inputFile, tmpDir.name);
+      const result = transformHTMLFile(inputFile, tmpDir.name);
 
       assert.equal(result, transformResult.SUCCESS);
 
@@ -32,7 +32,7 @@ describe('#transformFile', function() {
     it('should transform canvas-description-and-role.html and write output file', function() {
       const inputFile = './test/testdata/input/canvas-description-and-role.html';
       const referenceFile = './test/testdata/reference/transformed_canvas-description-and-role.html';
-      const result = transformFile(inputFile, tmpDir.name);
+      const result = transformHTMLFile(inputFile, tmpDir.name);
 
       assert.equal(result, transformResult.SUCCESS);
 

--- a/test/testTransformScript.js
+++ b/test/testTransformScript.js
@@ -139,6 +139,13 @@ describe('#testTransformSourceCode()', function() {
       const actual = transformSourceCodeString(inputString, false, false).code;
       assert.equal(actual, expected);
     });
+
+    it('should transform importScripts() parameter', function() {
+      const inputString = 'importScripts("../../resources/js-test.js");';
+      const expected = 'importScripts("../../resources/testharness.js");';
+      const actual = transformSourceCodeString(inputString, false, false).code;
+      assert.equal(actual, expected);
+    });
   });
 
   context('File-Level Transformations', function() {


### PR DESCRIPTION
WIP: ending internship so putting this PR out now.

This adds support for transforming .js files and recursively transforms directories. 
It also transforms `importScripts` calls to import testharness.js instead of js-test.js.

If `gc` is detected in the test, another `<script src="../../resources/gc.js"><script>` tag is added below the src to testharnessreport.js.

This is mostly untested. 